### PR TITLE
Corrección de visibilidad popover

### DIFF
--- a/src/modules/harvests/components/ModifyHarvestDetail.tsx
+++ b/src/modules/harvests/components/ModifyHarvestDetail.tsx
@@ -116,6 +116,7 @@ export const ModifyHarvestDetail = ({
             onClick={() => {
               formHarvestDetail.reset();
               setDialogOpen(false);
+              afterEffect && afterEffect(false);
             }}
           >
             Cancelar

--- a/src/modules/harvests/components/columns/ActionsHarvestProcessedTable.tsx
+++ b/src/modules/harvests/components/columns/ActionsHarvestProcessedTable.tsx
@@ -2,10 +2,7 @@ import { Button } from "@/components/ui/button";
 
 import { Pencil2Icon } from "@radix-ui/react-icons";
 
-
-import {
-  DropdownMenuItem
-} from "@/components/ui/dropdown-menu";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { ActionsTable } from "@/modules/core/components";
 import { ItemCopyIdRecord } from "@/modules/core/components/table/actions/ItemCopyIdRecord";
 import { ItemDeleteRecord } from "@/modules/core/components/table/actions/ItemDeleteRecord";

--- a/src/modules/harvests/components/columns/ActionsTableHarvest.tsx
+++ b/src/modules/harvests/components/columns/ActionsTableHarvest.tsx
@@ -17,7 +17,7 @@ interface Props {
   id: string;
 }
 
-export const ActionsHarvestTable = ({ mutate, id }: Props) => {
+export const ActionsTableHarvest = ({ mutate, id }: Props) => {
   const [openDropDownMenu, setOpenDropDownMenu] = useState(false);
 
   return (

--- a/src/modules/harvests/components/columns/ColumnsTableHarvest.tsx
+++ b/src/modules/harvests/components/columns/ColumnsTableHarvest.tsx
@@ -9,7 +9,7 @@ import { FormatNumber } from "@/modules/core/helpers/FormatNumber";
 import { FormatDate } from "@/modules/core/helpers/FormatDate";
 import { TableHarvest } from "../../interfaces/TableHarvest";
 import { formFieldsHarvest } from "../../utils";
-import { ActionsHarvestTable } from "./ActionsHarvestTable";
+import { ActionsTableHarvest } from "./ActionsTableHarvest";
 import { useDeleteHarvest } from "../../hooks/useDeleteHarvest";
 
 export let columnsHarvest: ColumnDef<TableHarvest>[] = [
@@ -91,7 +91,7 @@ columnsHarvest.push({
 
     const { mutate } = useDeleteHarvest();
 
-    return <ActionsHarvestTable mutate={mutate} id={id} />;
+    return <ActionsTableHarvest mutate={mutate} id={id} />;
   },
 });
 


### PR DESCRIPTION
Este commit fixed #1 issue

**Descripción**

En estos cambios se corrige el issue #1 , el cual al momento de cancelar la modificación de un registro de detalle de cosecha, ahora oculta correctamente el Popover de las acciones de la tabla.

**Problema Relacionado**

fixed #1 

**Tipo de Cambio**

Por favor, marca las opciones relevantes:
- [X] Corrección de error
- [ ] Nueva característica
- [ ] Mejora
- [ ] Refactorización
- [ ] Documentación
- [ ] Otro (especifica)

**¿Cómo Se Ha Probado Esto?**

Fueron pruebas manuales

**Lista de Verificación**

Por favor, asegúrate de que tu solicitud de extracción cumpla con los siguientes requisitos:
- [ ] Mi código sigue las pautas de estilo de este proyecto.
- [ ] He actualizado la documentación en consecuencia.
- [ ] He añadido pruebas para cubrir mis cambios.
- [ ] Todas las pruebas nuevas y existentes han pasado.

**Comentarios Adicionales**

Añade cualquier otro comentario o información relevante para la solicitud de extracción aquí.
